### PR TITLE
Add support for Swift package manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,18 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "CWRateKit",
+    platforms: [
+        .iOS(.v12)
+    ],
+    products: [
+        .library(name: "CWRateKit", targets: ["CWRateKit"])
+    ],
+    targets: [
+        .target(name: "CWRateKit", path: "CWRateKit"),
+    ],
+    swiftLanguageVersions: [.v5]
+)


### PR DESCRIPTION
Thank you for a nice looking library!

The README states that there's Swift package manager support.
However there's no Package manifest, so the library can't be used with that.

This PR adds the package and now the Xcode should be able to resolve the package properly.